### PR TITLE
Fix/rendering bands

### DIFF
--- a/example/src/examples/CogBitmapLayerExample.tsx
+++ b/example/src/examples/CogBitmapLayerExample.tsx
@@ -34,7 +34,7 @@ const cogLayerDefinition = {
     type: 'image',
     blurredTexture: false,
     clipLow: 1,
-    useChannel: 0,
+    useChannel: 1,
     useSingleColor: true,
   },
 

--- a/geoimage/src/geoimage/README.md
+++ b/geoimage/src/geoimage/README.md
@@ -27,7 +27,7 @@
 - `useDataForOpacity : boolean` - visualise data with opacity of each pixel according to its value **(default false)**
 - `alpha : number` - visualise entire image with specified opacity **(if useDataOpacity is false)**, values 0-100 **(default 100)**
 - `useHeatMap : boolean` - generate data as a color heatmap **(default true)**
- `useChannel : number | null` - specify a single channel to use **(default null)**
+- `useChannel : number | null` - specify a single channel to use; first channel is equal to 1, etc... for RGB(A) imagery leave it to `null` **(default null)**
 - `multiplier : number  ` - multiplies each value **(default 1.00)**
 - `clipLow : number | null`- generate only data greater than this **(default null)**
 

--- a/geoimage/src/geoimage/geoimage.ts
+++ b/geoimage/src/geoimage/geoimage.ts
@@ -154,7 +154,7 @@ export default class GeoImage {
 
     let channel = rasters[0];
 
-    optionsLocal.useChannelIndex = optionsLocal.useChannel == null ? null : optionsLocal.useChannel - 1;
+    optionsLocal.useChannelIndex ??= optionsLocal.useChannel == null ? null : optionsLocal.useChannel - 1;
     if (options.useChannelIndex != null) {
       if (rasters[optionsLocal.useChannelIndex]) {
         channel = rasters[optionsLocal.useChannelIndex];
@@ -298,7 +298,7 @@ export default class GeoImage {
     optionsLocal.nullColor = this.getColorFromChromaType(optionsLocal.nullColor);
     optionsLocal.clippedColor = this.getColorFromChromaType(optionsLocal.clippedColor);
     optionsLocal.color = this.getColorFromChromaType(optionsLocal.color);
-    optionsLocal.useChannelIndex = options.useChannel === null ? null : options.useChannel - 1;
+    optionsLocal.useChannelIndex ??= options.useChannel === null ? null : options.useChannel - 1;
 
     // console.log(rasters[0])
     /* console.log("raster 0 length: " + rasters[0].length)
@@ -394,7 +394,7 @@ export default class GeoImage {
       });
     } else {
       // if user defined channel does not exist
-      console.log(`Defined channel ${options.useChannel} does not exist, choose a different channel or set the useChannel property to null if you want to visualize RGB(A) imagery`);
+      console.log(`Defined channel(${options.useChannel}) or channel index(${options.useChannelIndex}) does not exist, choose a different channel or set the useChannel property to null if you want to visualize RGB(A) imagery`);
       const defaultColorData = this.getDefaultColor(size, optionsLocal.nullColor);
       defaultColorData.forEach((value, index) => {
         imageData.data[index] = value;

--- a/geoimage/src/geoimage/geoimage.ts
+++ b/geoimage/src/geoimage/geoimage.ts
@@ -24,7 +24,8 @@ export type GeoImageOptions = {
     useColorClasses? : boolean,
     useAutoRange?: boolean,
     useDataForOpacity?: boolean,
-    useChannel?: number | null,
+    useChannel?: Exclude<number, 0> | null,
+    useChannelIndex?: number | null,
     useSingleColor?: boolean,
     blurredTexture? : boolean,
     clipLow?: number | null,
@@ -67,6 +68,7 @@ export const DefaultGeoImageOptions: GeoImageOptions = {
   colorClasses: null,
   alpha: 100,
   useChannel: null,
+  useChannelIndex: null,
   noDataValue: undefined,
   numOfChannels: undefined,
   nullColor: [0, 0, 0, 0],
@@ -148,12 +150,14 @@ export default class GeoImage {
       width = input.width;
       height = input.height;
     }
+    const optionsLocal = { ...options };
 
     let channel = rasters[0];
 
-    if (options.useChannel != null) {
-      if (rasters[options.useChannel]) {
-        channel = rasters[options.useChannel]; // length = 65536
+    optionsLocal.useChannelIndex = optionsLocal.useChannel == null ? null : optionsLocal.useChannel - 1;
+    if (options.useChannelIndex != null) {
+      if (rasters[optionsLocal.useChannelIndex]) {
+        channel = rasters[optionsLocal.useChannelIndex];
       }
     }
 
@@ -161,7 +165,7 @@ export default class GeoImage {
 
     const numOfChannels = channel.length / (width * height);
 
-    let pixel:number = options.useChannel === null ? 0 : options.useChannel;
+    let pixel:number = options.useChannelIndex === null ? 0 : options.useChannelIndex;
 
     for (let i = 0, y = 0; y < height; y++) {
       for (let x = 0; x < width; x++, i++) {
@@ -294,6 +298,7 @@ export default class GeoImage {
     optionsLocal.nullColor = this.getColorFromChromaType(optionsLocal.nullColor);
     optionsLocal.clippedColor = this.getColorFromChromaType(optionsLocal.clippedColor);
     optionsLocal.color = this.getColorFromChromaType(optionsLocal.color);
+    optionsLocal.useChannelIndex = options.useChannel === null ? null : options.useChannel - 1;
 
     // console.log(rasters[0])
     /* console.log("raster 0 length: " + rasters[0].length)
@@ -302,7 +307,7 @@ export default class GeoImage {
     console.log("format: " + rasters[0].length / (width * height))
     */
 
-    if (optionsLocal.useChannel == null) {
+    if (optionsLocal.useChannelIndex == null) {
       if (channels === 1) {
         if (rasters[0].length / (width * height) === 1) {
           const channel = rasters[0];
@@ -372,10 +377,10 @@ export default class GeoImage {
           pixel += 1;
         }
       }
-    } else if (optionsLocal.useChannel <= optionsLocal.numOfChannels) {
+    } else if (optionsLocal.useChannelIndex < optionsLocal.numOfChannels && optionsLocal.useChannelIndex >= 0) {
       let channel = rasters[0];
-      if (rasters[optionsLocal.useChannel]) {
-        channel = rasters[optionsLocal.useChannel];
+      if (rasters[optionsLocal.useChannelIndex]) {
+        channel = rasters[optionsLocal.useChannelIndex];
       }
       // AUTO RANGE
       if (optionsLocal.useAutoRange) {
@@ -388,8 +393,8 @@ export default class GeoImage {
         imageData.data[index] = value;
       });
     } else {
-      // if user defined channel does not exist --> return greyscale image
-      console.log('Defined channel does not exist, displaying only grey values');
+      // if user defined channel does not exist
+      console.log(`Defined channel ${options.useChannel} does not exist, choose a different channel or set the useChannel property to null if you want to visualize RGB(A) imagery`);
       const defaultColorData = this.getDefaultColor(size, optionsLocal.nullColor);
       defaultColorData.forEach((value, index) => {
         imageData.data[index] = value;
@@ -417,7 +422,8 @@ export default class GeoImage {
 
   getColorValue(dataArray:[], options:GeoImageOptions, arrayLength:number, numOfChannels = 1) {
     const colorScale = chroma.scale(options.colorScale).domain(options.colorScaleValueRange);
-    let pixel:number = options.useChannel === null ? 0 : options.useChannel;
+    // channel index is equal to channel number - 1
+    let pixel:number = options.useChannelIndex === null ? 0 : options.useChannelIndex;
     const colorsArray = new Array(arrayLength);
 
     // if useColorsBasedOnValues is true


### PR DESCRIPTION
Fix of rendering correct bands = removes unwanted artefacts - vertical stripes

I added a new variable `useChannelIndex`. So there are now two channel definitions:  `useChannel` (for example for COG with 5 bands, this variable can vary between 1-5) and `useChannelIndex` which corresponds to the index of the channel within the raster (for the same example this would range between 0-4). 

Both variables are `null` by default. If we want to display RGB(A) imagery, they should stay null.